### PR TITLE
Fixes last pay index and associated notifications

### DIFF
--- a/src/lib/backends/core-lightning/index.ts
+++ b/src/lib/backends/core-lightning/index.ts
@@ -84,6 +84,7 @@ async function waitAnyInvoice(lastPayIndex: number): Promise<WaitAnyInvoiceRespo
     method: 'waitanyinvoice',
     params: { lastpay_index: lastPayIndex }
   })
+
   return response as WaitAnyInvoiceResponse
 }
 

--- a/src/lib/backends/core-lightning/utils.ts
+++ b/src/lib/backends/core-lightning/utils.ts
@@ -76,7 +76,8 @@ export function invoiceToPayment(invoice: Invoice): Payment {
     paid_at,
     payment_preimage,
     description,
-    expires_at
+    expires_at,
+    pay_index
   } = invoice
 
   const decodedInvoice = decode(bolt11)
@@ -96,7 +97,8 @@ export function invoiceToPayment(invoice: Invoice): Payment {
     description,
     destination: undefined,
     fee: null,
-    startedAt: new Date(timestamp * 1000).toISOString()
+    startedAt: new Date(timestamp * 1000).toISOString(),
+    payIndex: pay_index
   }
 }
 

--- a/src/lib/components/Notifications.svelte
+++ b/src/lib/components/Notifications.svelte
@@ -28,6 +28,7 @@
   }
 
   let notificationsToRender: Notification[] = []
+  let containerHeight: number
 
   const device = userAgent.getDevice()
 
@@ -97,7 +98,9 @@
 
 {#if notificationsToRender.length}
   <div
-    class="absolute top-0 p-4 w-96"
+    class="absolute top-0 p-4 w-96 max-h-screen overflow-hidden"
+    class:overflow-y-auto={containerHeight && containerHeight >= window.innerHeight}
+    bind:clientHeight={containerHeight}
     class:right-0={device.type !== 'mobile'}
     class:w-full={device.type === 'mobile'}
   >

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -29,7 +29,7 @@ export const DEFAULT_SETTINGS: Settings = {
   invoiceExpiry: DEFAULT_INVOICE_EXPIRY,
   sendMaxFeePercent: 0.5,
   sendTimeoutSeconds: 120,
-  notifications: false,
+  notifications: true,
   darkmode: false
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -88,6 +88,7 @@ export type Payment = {
   hash: string
   preimage?: string
   destination?: string
+  payIndex?: number
 }
 
 type PaymentDirection = 'receive' | 'send'

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -467,3 +467,11 @@ export async function getBitcoinExchangeRate(): Promise<BitcoinExchangeRates | n
 }
 
 export const noop = () => {}
+
+export function deriveLastPayIndex(payments: Payment[]): number {
+  return payments.length
+    ? payments.reduce((currentHighestIndex, { payIndex }) => {
+        return payIndex && payIndex > currentHighestIndex ? payIndex : currentHighestIndex
+      }, 0)
+    : 0
+}


### PR DESCRIPTION
This PR will now derive a last pay index from node payments if there is not one in local storage. This prevents a user from receiving a notification for every invoice that has been paid before they first logged in to the app. Also included are some adjustments to overflows for the notifications container.