### PR TITLE
Fix: BTC Exponential Values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-app",
-  "version": "1.0.4-0.0.1",
+  "version": "1.0.4-0.0.2",
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",

--- a/src/lib/components/PaymentRow.svelte
+++ b/src/lib/components/PaymentRow.svelte
@@ -35,7 +35,7 @@
   on:click={() => goto(`/payments/${id}`)}
   class="flex items-start justify-between py-4 border-t w-full cursor-pointer"
 >
-  <div class="flex items-start w-3/4">
+  <div class="flex items-start w-3/5">
     <div
       class="border rounded-full w-8 mr-2 {direction === 'receive' && status === 'complete'
         ? 'border-utility-success text-utility-success'
@@ -68,7 +68,7 @@
     </div>
   </div>
 
-  <div class="flex flex-col text-right w-1/4">
+  <div class="flex flex-col text-right w-2/5">
     <p class="font-bold">
       {abs}
       {formatValueForDisplay({

--- a/src/lib/conversion.ts
+++ b/src/lib/conversion.ts
@@ -2,6 +2,8 @@ import Big from 'big.js'
 import { bitcoinExchangeRates$ } from './streams'
 import { BitcoinDenomination, type Denomination, type FiatDenomination } from './types'
 
+Big.NE = -21
+
 export function msatsToBtc(msats: string): string {
   return Big(msats === 'any' ? '0' : msats)
     .div(1e11)


### PR DESCRIPTION
For really low Bitcoin values eg `0.00000023` the Big number `toString` value was rendering them in exponential format (`2.3e-7`). This PR updates the settings for Big.js so that it will render them correctly. Also included is a width change in the `PaymentRow` component so that there is enough width to display the correct values.