### PR TITLE
Fix switch denomination bug for balance of 0

### DIFF
--- a/src/lib/components/Value.svelte
+++ b/src/lib/components/Value.svelte
@@ -50,7 +50,7 @@
 
     const newPrimaryValue =
       secondary === '0'
-        ? ''
+        ? '0'
         : formatValueForDisplay({
             value: secondary,
             denomination: currentSettings.secondaryDenomination


### PR DESCRIPTION
Fixes issue where the number 0 disappears from `Value` component when the denomination toggle is used, for any node that has balance of 0

![Screen Shot 2022-11-28 at 6 09 36 PM](https://user-images.githubusercontent.com/30157175/204400464-a6a1ba34-5b8d-4785-95df-d7159f7412b2.png)
