### PR TITLE
Fix: Adds touch action to pin entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-app",
-  "version": "1.1.0",
+  "version": "1.1.0-0.0.1",
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",

--- a/src/app.html
+++ b/src/app.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=5" />
+    <meta name="viewport" content="initial-scale=1.0, width=device-width">
     <meta name="description" content="A user interface for your Core Lightning node" />
     <meta name="apple-mobile-web-app-title" content="Clams" />
     <meta name="application-name" content="Clams" />

--- a/src/lib/components/PinEntry.svelte
+++ b/src/lib/components/PinEntry.svelte
@@ -76,7 +76,7 @@
     {#each buttons as { main, sub }}
       <div
         class:justify-center={main === 0}
-        class="flex flex-col items-center justify-start m-1 w-16 h-16 md:w-20 md:h-20 border rounded-lg p-2 md:p-4 active:bg-neutral-100 dark:active:bg-neutral-800 cursor-pointer"
+        class="flex flex-col items-center justify-start m-1 w-16 h-16 md:w-20 md:h-20 border rounded-lg p-2 md:p-4 active:bg-neutral-100 dark:active:bg-neutral-800 cursor-pointer touch-manipulation"
         on:pointerdown={handlePinEntry(main)}
       >
         <div class="text-xl md:text-2xl">{main}</div>
@@ -85,7 +85,7 @@
     {/each}
 
     <div
-      class="w-16 h-16 md:w-20 md:h-20 border rounded absolute bottom-0 md:right-1 right-7 flex m-1 items-center justify-center cursor-pointer"
+      class="w-16 h-16 md:w-20 md:h-20 border rounded absolute bottom-0 md:right-1 right-7 flex m-1 items-center justify-center cursor-pointer touch-manipulation"
       on:pointerdown={handleClear}
     >
       <div class="w-6">


### PR DESCRIPTION
Sometimes on Safari the pinpad is a bit laggy when entering a pin. Adding a [`touch-action`](https://webkit.org/blog/5610/more-responsive-tapping-on-ios/) parameter should fix the lag as it tells the browser that a double tap is not valid, so it does not wait for it and fires the event immediately.