### PR TITLE
Fix: Handle Decode Bol11 Fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-app",
-  "version": "1.1.1-0.0.1",
+  "version": "1.1.1-0.0.2",
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -133,3 +133,8 @@ export type ParsedNodeAddress = {
   ip: string
   port?: number
 }
+
+export type DecodedInvoice = {
+  paymentRequest: string
+  sections: { name: string; value?: string | number }[]
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -19,13 +19,11 @@ import type {
   BitcoinExchangeRates,
   FormattedSections,
   ParsedNodeAddress,
-  Auth
+  Auth,
+  DecodedInvoice
 } from './types'
 
-export function formatDecodedInvoice(decodedInvoice: {
-  paymentRequest: string
-  sections: { name: string; value?: string | number }[]
-}): {
+export function formatDecodedInvoice(decodedInvoice: DecodedInvoice): {
   paymentRequest: string
   expiry: number
   description: string


### PR DESCRIPTION
This PR adds error handling when decoding the `bolt11` value from a `pay` entry in the case there is a non standard value that does not start with `ln` which causes the decoder library we use to fail.