### PR TITLE
Fix: Unique Payment ID

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-app",
-  "version": "1.1.1-0.0.2",
+  "version": "1.1.1-0.0.3",
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",

--- a/src/lib/backends/core-lightning/utils.ts
+++ b/src/lib/backends/core-lightning/utils.ts
@@ -19,7 +19,6 @@ export function invoiceStatusToPaymentStatus(status: InvoiceStatus): Payment['st
 
 export function invoiceToPayment(invoice: Invoice): Payment {
   const {
-    label,
     bolt11,
     payment_hash,
     amount_received_msat,
@@ -43,7 +42,7 @@ export function invoiceToPayment(invoice: Invoice): Payment {
   }
 
   return {
-    id: label || payment_hash,
+    id: payment_hash,
     bolt11: bolt11 || null,
     hash: payment_hash,
     direction: 'receive',
@@ -68,7 +67,6 @@ export function payToPayment(pay: Pay): Payment {
     payment_hash,
     status,
     created_at,
-    label,
     preimage,
     amount_msat,
     amount_sent_msat
@@ -88,7 +86,7 @@ export function payToPayment(pay: Pay): Payment {
   const amountMsat = formatMsat(amount_msat)
 
   return {
-    id: label || payment_hash,
+    id: payment_hash,
     destination,
     bolt11: bolt11 || null,
     status,


### PR DESCRIPTION
We were previously preferring to use a payment `label` for a unique payment ID and then falling back to the `payment_hash` if needed. It seems as reported in [this issue](https://github.com/clams-tech/browser-app/issues/70#issuecomment-1369300337) that we cannot rely on the `label` to be unique.
This PR simply changes the payment `id` property to always be the `payment_hash` as that should reliably be unique.