### PR TITLE
Fix: Reverts Payment ID to Label

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-app",
-  "version": "1.1.1-0.0.8",
+  "version": "1.1.1-0.0.9",
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",

--- a/src/lib/backends/core-lightning/utils.ts
+++ b/src/lib/backends/core-lightning/utils.ts
@@ -21,6 +21,7 @@ export function invoiceToPayment(invoice: Invoice): Payment {
   const {
     bolt11,
     payment_hash,
+    label,
     amount_received_msat,
     amount_msat,
     status,
@@ -42,7 +43,7 @@ export function invoiceToPayment(invoice: Invoice): Payment {
   }
 
   return {
-    id: payment_hash,
+    id: label || payment_hash,
     bolt11: bolt11 || null,
     hash: payment_hash,
     direction: 'receive',
@@ -64,6 +65,7 @@ export function payToPayment(pay: Pay): Payment {
   const {
     bolt11,
     destination,
+    label,
     payment_hash,
     status,
     created_at,
@@ -86,7 +88,7 @@ export function payToPayment(pay: Pay): Payment {
   const amountMsat = formatMsat(amount_msat)
 
   return {
-    id: payment_hash,
+    id: label || payment_hash,
     destination,
     bolt11: bolt11 || null,
     status,


### PR DESCRIPTION
This PR reverts to using the label as the preferred `payment.id` as that is what is used throughout the app and the issue that was trying to be solved by this changed turned out to be something else in the end.