### PR TITLE
1.2.0-0.4.1 - Fix: LNURL Pay Summary

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-app",
-  "version": "1.2.0-0.4.0",
+  "version": "1.2.0-0.4.1",
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",

--- a/src/routes/lnurl/components/pay.svelte
+++ b/src/routes/lnurl/components/pay.svelte
@@ -334,9 +334,9 @@
 {#if slide === 3}
   <Slide {back} direction={previousSlide > slide ? 'right' : 'left'}>
     <Summary
-      type="payment_request"
+      type="lnurl"
       direction="send"
-      destination={serviceName}
+      destination={address || serviceName}
       {description}
       value={amount}
       {requesting}


### PR DESCRIPTION
A small PR that ensures that we display the lightning address as the destination if possible and ensure that the destination is not truncated by setting the payment type to `lnurl`.