### PR TITLE
1.4.1-0.2.0: Default Dark Mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-app",
-  "version": "1.4.1-0.1.0",
+  "version": "1.4.1-0.2.0",
   "scripts": {
     "dev": "vite dev",
     "dev-http": "vite dev --mode http",

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -37,7 +37,10 @@ export const DEFAULT_SETTINGS: Settings = {
   sendMaxFeePercent: 0.5,
   sendTimeoutSeconds: 120,
   notifications: true,
-  darkmode: false,
+  darkmode:
+    typeof window !== 'undefined' &&
+    window.matchMedia &&
+    window.matchMedia('(prefers-color-scheme: dark)').matches,
   encrypt: false,
   wsProxy: WS_PROXY,
   directConnection: undefined


### PR DESCRIPTION
This PR sets the initial value for `darkMode` based on the system settings. The user can continue to use the toggle in the settings route to modify, but the initial value is more likely to be correct now.

Closes #107 