### PR TITLE
1.4.1-0.2.1 - Fix: Various Fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-app",
-  "version": "1.4.1-0.2.0",
+  "version": "1.4.1-0.2.1",
   "scripts": {
     "dev": "vite dev",
     "dev-http": "vite dev --mode http",

--- a/src/lib/elements/Modal.svelte
+++ b/src/lib/elements/Modal.svelte
@@ -17,7 +17,7 @@
     'w-full h-full fixed top-0 left-0 backdrop-blur-sm dark:bg:neutral-50 bg-neutral-900/40 flex flex-col items-center z-50'
 
   const modalStyles =
-    'bg-neutral-50 dark:text-neutral-900 shadow-lg py-4 px-6 relative flex items-center justify-center flex-col max-h-[80%] overflow-y-auto'
+    'bg-neutral-50 dark:bg-neutral-800 shadow-lg py-4 px-6 relative flex items-center justify-center flex-col max-h-[80%] overflow-y-auto'
 
   function closeModal() {
     dispatch('close')

--- a/src/routes/connect/+page.svelte
+++ b/src/routes/connect/+page.svelte
@@ -70,7 +70,6 @@
 
     if (decodedRune) {
       blurRuneInput()
-      showDecodedRuneModal = true
     }
   }
 
@@ -384,13 +383,23 @@
         </div>
       </div>
 
-      <div class="flex items-center mb-6 font-thin text-sm dark:text-purple-200 text-purple-700">
-        <div class="w-5 mr-2 border-2 rounded-full border-current">
-          {@html info}
+      <div
+        class="flex items-center w-full justify-between mb-6 font-thin text-sm dark:text-purple-200 text-purple-700"
+      >
+        <div class="flex items-center">
+          <div class="w-5 mr-2 border-2 rounded-full border-current">
+            {@html info}
+          </div>
+          <a href={DOCS_RUNE_LINK} target="_blank" class="hover:underline" rel="noopener noreferrer"
+            >{$translate('app.hints.help')}</a
+          >
         </div>
-        <a href={DOCS_RUNE_LINK} target="_blank" class="hover:underline" rel="noopener noreferrer"
-          >{$translate('app.hints.help')}</a
-        >
+
+        {#if decodedRune}
+          <div in:fade>
+            <Button text="Decode Rune" on:click={() => (showDecodedRuneModal = true)} small />
+          </div>
+        {/if}
       </div>
 
       <div class="w-full">

--- a/src/routes/scan/+page.svelte
+++ b/src/routes/scan/+page.svelte
@@ -195,7 +195,7 @@
 {/if}
 
 {#if slide === 2}
-  <Slide back={prev} direction={previousSlide > slide ? 'right' : 'left'}>
+  <Slide back={() => to(previousSlide)} direction={previousSlide > slide ? 'right' : 'left'}>
     <Summary
       destination={$sendPayment$.destination}
       type="bolt11"

--- a/src/routes/send/+page.svelte
+++ b/src/routes/send/+page.svelte
@@ -191,10 +191,7 @@
 {/if}
 
 {#if slide === 3}
-  <Slide
-    back={() => ($sendPayment$.amount ? to(0) : prev())}
-    direction={previousSlide > slide ? 'right' : 'left'}
-  >
+  <Slide back={() => to(previousSlide)} direction={previousSlide > slide ? 'right' : 'left'}>
     <Summary
       direction="send"
       type={$sendPayment$.type}


### PR DESCRIPTION
- Changes modal background to be dark when in dark mode
- Add a button to trigger decoded rune modal instead of automatically triggering
- Fix back button on routes with multiple slides. Previously when you scan an invoice with an amount and click back, instead of going back to the scanner, it would go the the Amount slide