### PR TITLE
1.4.1-0.2.2 - Fix: Encrypt Modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-app",
-  "version": "1.4.1-0.2.1",
+  "version": "1.4.1-0.2.2",
   "scripts": {
     "dev": "vite dev",
     "dev-http": "vite dev --mode http",

--- a/src/lib/elements/Modal.svelte
+++ b/src/lib/elements/Modal.svelte
@@ -17,7 +17,7 @@
     'w-full h-full fixed top-0 left-0 backdrop-blur-sm dark:bg:neutral-50 bg-neutral-900/40 flex flex-col items-center z-50'
 
   const modalStyles =
-    'bg-neutral-50 dark:bg-neutral-800 shadow-lg py-4 px-6 relative flex items-center justify-center flex-col max-h-[80%] overflow-y-auto'
+    'bg-neutral-50 dark:bg-neutral-800 shadow-lg py-4 px-6 relative flex items-center justify-center flex-col max-h-[85%] overflow-y-auto'
 
   function closeModal() {
     dispatch('close')

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -124,7 +124,12 @@
 </Slide>
 
 {#if showPinEntryModal}
-  <Modal on:close={() => (showPinEntryModal = false)}>
+  <Modal
+    on:close={() => {
+      showPinEntryModal = false
+      toggle('encrypt')
+    }}
+  >
     <h2 class="p-4 md:mb-6 mb-4 font-semibold text-xl md:text-2xl">
       {$translate('app.headings.encrypt')}
     </h2>


### PR DESCRIPTION
- Increased modal max-height as the pin entry was requiring scroll iphone SE
- Toggle encrypt state back to off if modal is manually closed