### PR TITLE
Fix - Routing Performance mobile style

### DIFF
--- a/src/routes/bkpr/components/RoutingPerformance.svelte
+++ b/src/routes/bkpr/components/RoutingPerformance.svelte
@@ -44,7 +44,8 @@
       <ErrorMsg message={$channelsAPY$.error} closable={false} />
     </div>
   {:else if net}
-    <div class="mt-6 rounded-lg shadow-lg border">
+    <p>hello</p>
+    <div class="mt-6 rounded-lg shadow-lg border overflow-x-scroll">
       <table class="w-full">
         <thead>
           <tr class="text-left uppercase">

--- a/src/routes/bkpr/components/RoutingPerformance.svelte
+++ b/src/routes/bkpr/components/RoutingPerformance.svelte
@@ -44,7 +44,6 @@
       <ErrorMsg message={$channelsAPY$.error} closable={false} />
     </div>
   {:else if net}
-    <p>hello</p>
     <div class="mt-6 rounded-lg shadow-lg border overflow-x-scroll">
       <table class="w-full">
         <thead>


### PR DESCRIPTION
I played around rounding the values, trying to accommodate very large and very small values and it was a bit of headache. So I think for now this should be sufficient. The user can scroll right and left on the table to view any columns that over-flow

![Screen Shot 2023-02-26 at 11 53 12 AM](https://user-images.githubusercontent.com/30157175/221424732-1c003181-240e-440f-8867-c4b4a7401060.png)
