### PR TITLE
1.6.0-0.0.1 - Fix: Rune Modal Overflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-app",
-  "version": "1.6.0",
+  "version": "1.6.0-0.0.1",
   "scripts": {
     "dev": "vite dev",
     "dev-http": "vite dev --mode http",

--- a/src/routes/connect/+page.svelte
+++ b/src/routes/connect/+page.svelte
@@ -410,7 +410,7 @@
 
 {#if showDecodedRuneModal && decodedRune}
   <Modal on:close={() => (showDecodedRuneModal = false)}>
-    <div in:fade|local={{ duration: 250 }} class="w-[25rem] max-w-full">
+    <div in:fade|local={{ duration: 250 }} class="w-[25rem] max-w-full h-full overflow-auto">
       <h4 class="font-semibold mb-2 w-full text-2xl">{$translate('app.labels.rune_summary')}</h4>
 
       <SummaryRow>


### PR DESCRIPTION
- Adds height and `overflow-auto` to the Rune modal so that when the content reaches full height it will scroll rather than truncate.