### PR TITLE
1.6.0-0.0.2: Update - Lnmessage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-app",
-  "version": "1.6.0-0.0.1",
+  "version": "1.6.0-0.0.2",
   "scripts": {
     "dev": "vite dev",
     "dev-http": "vite dev --mode http",
@@ -59,7 +59,7 @@
     "js-lnurl": "^0.5.1",
     "jsqr": "^1.4.0",
     "light-bolt11-decoder": "^3.0.0",
-    "lnmessage": "^0.2.0",
+    "lnmessage": "^0.2.1",
     "lodash.debounce": "^4.0.8",
     "lodash.isequal": "^4.5.0",
     "qr-code-styling": "^1.6.0-rc.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1554,10 +1554,10 @@ listr2@^4.0.5:
     through "^2.3.8"
     wrap-ansi "^7.0.0"
 
-lnmessage@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/lnmessage/-/lnmessage-0.2.0.tgz#3f24f2f6aef31f8c7dbcd48903087d02ee050ca6"
-  integrity sha512-zyNLn3BPz+lQq0B7Vu3Y93qjBeLxyZAHEMRzhUAHdEVlRhg4wKViJjjiKSqxs8pMHfHCizMu73U2lt38OSvpjw==
+lnmessage@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/lnmessage/-/lnmessage-0.2.1.tgz#ff8daaa52632c12b4f90559f04922e3e5f6ecb80"
+  integrity sha512-TZQNZP4EYyaHE4bRuoGb81NbSGkyAwzZkSbrYHKLpKpe2yLlBp7vgru9n9d8iEMQNlkyGLIwvi2eRbRJPkqi1Q==
   dependencies:
     "@noble/hashes" "^1.2.0"
     "@noble/secp256k1" "^1.7.1"


### PR DESCRIPTION
- Updates to the latest Lnmessage version 0.2.1 which has a fix for an edge case of when a disconnect event happens when the message buffer still has data. When Lnmessage reconnects, that message data corrupts the new incoming messages. [PR for Lnmessage is here](https://github.com/aaronbarnardsound/lnmessage/pull/27).