### PR TITLE
1.6.1: Hotfix - Removes Expiry Log

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-app",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "scripts": {
     "dev": "vite dev",
     "dev-http": "vite dev --mode http",

--- a/src/lib/components/Summary.svelte
+++ b/src/lib/components/Summary.svelte
@@ -210,7 +210,6 @@
 
     <!-- EXPIRY -->
     {#if expiry}
-      {console.log({ expiry })}
       <SummaryRow>
         <span slot="label">{$translate('app.labels.expires')}:</span>
         <span class="flex items-center w-full justify-end" slot="value">


### PR DESCRIPTION
- Removes expiry log which was also rendering `undefined` on the payment summary page.