### PR TITLE
1.6.1-0.1.2: Enhancement - Exchange Rate API

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@playwright/test": "^1.28.1",
     "@sveltejs/adapter-static": "^2.0.0",
-    "@sveltejs/kit": "^1.8.4",
+    "@sveltejs/kit": "^1.15.2",
     "@types/big.js": "^6.1.5",
     "@types/crypto-js": "^4.1.1",
     "@types/hammerjs": "^2.0.41",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-app",
-  "version": "1.6.1-0.0.2",
+  "version": "1.6.1-0.1.2",
   "scripts": {
     "dev": "vite dev",
     "dev-http": "vite dev --mode http",

--- a/src/lib/components/Summary.svelte
+++ b/src/lib/components/Summary.svelte
@@ -210,7 +210,6 @@
 
     <!-- EXPIRY -->
     {#if expiry}
-      {console.log({ expiry })}
       <SummaryRow>
         <span slot="label">{$translate('app.labels.expires')}:</span>
         <span class="flex items-center w-full justify-end" slot="value">

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -9,13 +9,9 @@ import { translate } from './i18n/translations'
 export const DEV = import.meta.env.DEV
 export const MODE = import.meta.env.MODE
 
-// export const API_HOST = 'api.clams.tech'
-// export const API_URL = `https://${API_HOST}`
-// export const WS_PROXY = `wss://${API_HOST}/ws-proxy`
-
-export const API_HOST = 'localhost:3000'
-export const API_URL = `http://${API_HOST}`
-export const WS_PROXY = `ws://${API_HOST}/ws-proxy`
+export const API_HOST = 'api.clams.tech'
+export const API_URL = `https://${API_HOST}`
+export const WS_PROXY = `wss://${API_HOST}/ws-proxy`
 
 export const SEC_IN_MS = 1000
 export const MIN_IN_MS = 60 * 1000

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -9,14 +9,13 @@ import { translate } from './i18n/translations'
 export const DEV = import.meta.env.DEV
 export const MODE = import.meta.env.MODE
 
-export const WS_PROXY = 'wss://wsproxy.clams.tech'
-export const LNURL_PROXY = 'https://wsproxy.clams.tech/proxy'
+// export const API_HOST = 'api.clams.tech'
+// export const API_URL = `https://${API_HOST}`
+// export const WS_PROXY = `wss://${API_HOST}/ws-proxy`
 
-export const COIN_GECKO_PRICE_ENDPOINT = `https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=${Object.keys(
-  FiatDenomination
-).join(',')}`
-
-export const COINBASE_PRICE_ENDPOINT = 'https://api.coinbase.com/v2/exchange-rates?currency=BTC'
+export const API_HOST = 'localhost:3000'
+export const API_URL = `http://${API_HOST}`
+export const WS_PROXY = `ws://${API_HOST}/ws-proxy`
 
 export const SEC_IN_MS = 1000
 export const MIN_IN_MS = 60 * 1000

--- a/src/lib/side-effects.ts
+++ b/src/lib/side-effects.ts
@@ -1,4 +1,7 @@
 import { from, merge, timer } from 'rxjs'
+import lightning from '$lib/lightning'
+import { deriveLastPayIndex, encryptWithAES, getBitcoinExchangeRate, logger } from './utils'
+
 import {
   distinctUntilChanged,
   distinctUntilKeyChanged,
@@ -7,8 +10,6 @@ import {
   switchMap,
   tap
 } from 'rxjs/operators'
-import { deriveLastPayIndex, encryptWithAES, getBitcoinExchangeRate, logger } from './utils'
-import lightning from '$lib/lightning'
 
 import {
   AUTH_STORAGE_KEY,

--- a/src/lib/side-effects.ts
+++ b/src/lib/side-effects.ts
@@ -7,8 +7,7 @@ import {
   distinctUntilKeyChanged,
   filter,
   skip,
-  switchMap,
-  tap
+  switchMap
 } from 'rxjs/operators'
 
 import {
@@ -142,8 +141,7 @@ function registerSideEffects() {
 
   const fiatDenominationChange$ = settings$.pipe(
     distinctUntilKeyChanged('fiatDenomination'),
-    skip(1),
-    tap(({ fiatDenomination }) => console.log({ fiatDenomination }))
+    skip(1)
   )
 
   // get and update bitcoin exchange rate by poll or if fiat denomination changes

--- a/src/routes/lnurl/+page.svelte
+++ b/src/routes/lnurl/+page.svelte
@@ -5,7 +5,7 @@
   import Withdraw from './components/withdraw.svelte'
   import warning from '$lib/icons/warning'
   import Spinner from '$lib/elements/Spinner.svelte'
-  import { LNURL_PROXY } from '$lib/constants'
+  import { API_URL } from '$lib/constants'
   import { decodeLightningAddress } from '$lib/utils'
   import type { PageData } from './$types'
   import { goto } from '$app/navigation'
@@ -55,9 +55,9 @@
       if (!tag) {
         parsingLnurl = true
 
-        const result = await fetch(LNURL_PROXY, { headers: { 'Target-URL': url.toString() } }).then(
-          (res) => res.json()
-        )
+        const result = await fetch(`${API_URL}/http-proxy`, {
+          headers: { 'Target-URL': url.toString() }
+        }).then((res) => res.json())
 
         if (result.status === 'ERROR') {
           parseLnurlError = result.reason

--- a/src/routes/lnurl/components/auth.svelte
+++ b/src/routes/lnurl/components/auth.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { goto } from '$app/navigation'
-  import { LNURL_PROXY } from '$lib/constants'
+  import { API_URL } from '$lib/constants'
   import Button from '$lib/elements/Button.svelte'
   import ErrorMsg from '$lib/elements/ErrorMsg.svelte'
   import check from '$lib/icons/check'
@@ -28,7 +28,7 @@
       loginURL.searchParams.set('key', signer.publicKey)
       loginURL.searchParams.set('t', Date.now().toString())
 
-      const authResponse = await fetch(LNURL_PROXY, {
+      const authResponse = await fetch(`${API_URL}/http-proxy`, {
         headers: { 'Target-URL': loginURL.toString() }
       }).then((res) => res.json())
 

--- a/src/routes/lnurl/components/pay.svelte
+++ b/src/routes/lnurl/components/pay.svelte
@@ -3,7 +3,7 @@
   import Amount from '$lib/components/Amount.svelte'
   import TextScreen from '$lib/components/TextScreen.svelte'
   import Summary from '$lib/components/Summary.svelte'
-  import { LNURL_PROXY } from '$lib/constants'
+  import { API_URL } from '$lib/constants'
   import { convertValue } from '$lib/conversion'
   import Button from '$lib/elements/Button.svelte'
   import ErrorMsg from '$lib/elements/ErrorMsg.svelte'
@@ -195,7 +195,7 @@
         url.searchParams.set('comment', description)
       }
 
-      const result = await fetch(LNURL_PROXY, {
+      const result = await fetch(`${API_URL}/http-proxy`, {
         headers: {
           'Target-URL': url.toString()
         }

--- a/src/routes/lnurl/components/withdraw.svelte
+++ b/src/routes/lnurl/components/withdraw.svelte
@@ -2,7 +2,7 @@
   import { goto } from '$app/navigation'
   import Amount from '$lib/components/Amount.svelte'
   import Summary from '$lib/components/Summary.svelte'
-  import { LNURL_PROXY } from '$lib/constants'
+  import { API_URL } from '$lib/constants'
   import { convertValue } from '$lib/conversion'
   import Button from '$lib/elements/Button.svelte'
   import ErrorMsg from '$lib/elements/ErrorMsg.svelte'
@@ -117,7 +117,7 @@
       url.searchParams.set('k1', k1)
       url.searchParams.set('pr', payment.invoice as string)
 
-      const result = await fetch(LNURL_PROXY, {
+      const result = await fetch(`${API_URL}/http-proxy`, {
         headers: {
           'Target-URL': url.toString()
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -230,10 +230,10 @@
   resolved "https://registry.yarnpkg.com/@sveltejs/adapter-static/-/adapter-static-2.0.0.tgz#508d0eb5d060094b49c592cfcbd72349b4f1d6bb"
   integrity sha512-M9F8EyCIdVcpZu0zvS7U7v+rc7elNNDUkMHLsOkJYlfQ9rDdif3fqteMqddcrq1lFPEGH1ErdTjpsXdb3k1e8w==
 
-"@sveltejs/kit@^1.8.4":
-  version "1.8.4"
-  resolved "https://registry.yarnpkg.com/@sveltejs/kit/-/kit-1.8.4.tgz#5f2fccb2c26acb1719422436ece061e56a1e4516"
-  integrity sha512-SUNHiaFuvOxeu/3wVLbdR2ki9sqcPEQUOtxWulI+H7fa1JfSTYuA0KgjValVlKBUlyWiW9XKyTtSE+I+qQOToA==
+"@sveltejs/kit@^1.15.2":
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/@sveltejs/kit/-/kit-1.15.2.tgz#2d351b15aa39ab792c36c2c236c7e31a2010a6b0"
+  integrity sha512-rLNxZrjbrlPf8AWW8GAU4L/Vvu17e9v8EYl7pUip7x72lTft7RcxeP3z7tsrHpMSBBxC9o4XdKzFvz1vMZyXZw==
   dependencies:
     "@sveltejs/vite-plugin-svelte" "^2.0.0"
     "@types/cookie" "^0.5.1"


### PR DESCRIPTION
This PR connects Clams to a new server endpoint: `https://api.clams.tech` which has a new codebase. Exchange rates will be fetched and cached by the server, and the app will fetch from there instead. This will help with rate limits on the external exchange rate API's.
To save bandwidth the app will only fetch the exchange rate for the fiat denomination that is set in the app. A new exchange rate will be fetched every 5 minutes or when the fiat denomination is changed.

The wsproxy lives at the /ws-proxy route on the new server and Clams now connects to that.
The https proxy for lnurl calls lives at /http-proxy.

Closes #144 