### PR TITLE
1.7.0-1.7.1 - Fix: Update BOLT11 decode function to accommodate invoice prepended with lightning:

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-app",
-  "version": "1.7.0",
+  "version": "1.7.0-1.7.1",
   "scripts": {
     "dev": "vite dev",
     "dev-http": "vite dev --mode http",

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -420,6 +420,11 @@ export function decodeLightningAddress(val: string): { username: string; domain:
 }
 
 export function decodeBolt11(bolt11: string): (FormattedDecodedBolt11 & { bolt11: string }) | null {
+  // Remove prepended string if found
+  if (bolt11.includes('lightning:')) {
+    bolt11 = bolt11.replace('lightning:', '')
+  }
+
   try {
     const { sections } = bolt11Decoder(bolt11) as DecodedInvoice
 


### PR DESCRIPTION
I caught in my logs that the app was not able to decode two of my "pays". 

On examination of the return from `listpays` method I noticed that two of my `BOLT11` invoices have `lightning:` prepended to the invoice. 

Small fix here to accommodate. 