### PR TITLE
1.7.0-1.7.2 - Enhancement: Add option to make connection via URL params

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-app",
-  "version": "1.7.0-1.7.1",
+  "version": "1.7.0-1.7.2",
   "scripts": {
     "dev": "vite dev",
     "dev-http": "vite dev --mode http",

--- a/src/lib/components/ConnectionSettings.svelte
+++ b/src/lib/components/ConnectionSettings.svelte
@@ -51,7 +51,7 @@
 
   let urlValidationTimeout: NodeJS.Timeout
 
-  function validateCustomProxy() {
+  export function validateCustomProxy() {
     customProxyUrlError = ''
     urlValidationTimeout && clearTimeout(urlValidationTimeout)
     customProxyUrlAwaitingValidation = true

--- a/src/lib/components/ConnectionSettings.svelte
+++ b/src/lib/components/ConnectionSettings.svelte
@@ -51,7 +51,7 @@
 
   let urlValidationTimeout: NodeJS.Timeout
 
-  export function validateCustomProxy() {
+  function validateCustomProxy() {
     customProxyUrlError = ''
     urlValidationTimeout && clearTimeout(urlValidationTimeout)
     customProxyUrlAwaitingValidation = true

--- a/src/routes/connect/+page.svelte
+++ b/src/routes/connect/+page.svelte
@@ -46,19 +46,21 @@
     const connectionType = data.type || 'proxy' // direct | proxy | undefined
     const connectionValue = data.value || WS_PROXY // proxyUrl | wss: | ws: | undefined
 
+    const update: Partial<Settings> = {}
+
+    // Set connection type
+    if (connectionType === 'proxy') {
+      // @TODO validate custom proxy
+      update.wsProxy = connectionValue
+      update.directConnection = undefined
+    } else if (connectionType === 'direct') {
+      update.directConnection = connectionValue as 'ws:' | 'wss:' | undefined
+    }
+
+    settings$.next({ ...$settings$, ...update })
+
+    // Validate address & rune then save to make connection
     if (validateParsedNodeAddress(parseNodeAddress(address)) && decode(token)) {
-      const update: Partial<Settings> = {}
-
-      if (connectionType === 'proxy') {
-        // @TODO validate custom proxy
-        update.wsProxy = connectionValue
-        update.directConnection = undefined
-      } else if (connectionType === 'direct') {
-        update.directConnection = connectionValue as 'ws:' | 'wss:' | undefined
-      }
-
-      settings$.next({ ...$settings$, ...update })
-
       saveRune().then(() => {
         initialized = true
       })

--- a/src/routes/connect/+page.svelte
+++ b/src/routes/connect/+page.svelte
@@ -49,12 +49,12 @@
     const update: Partial<Settings> = {}
 
     // Set connection type
-    if (connectionType === 'proxy') {
-      // @TODO validate custom proxy
+    if (connectionType === 'direct') {
+      update.directConnection = connectionValue as 'ws:' | 'wss:' | undefined
+    } else if (connectionType === 'proxy' && connectionValue) {
+      // @TODO validate custom proxy?
       update.wsProxy = connectionValue
       update.directConnection = undefined
-    } else if (connectionType === 'direct') {
-      update.directConnection = connectionValue as 'ws:' | 'wss:' | undefined
     }
 
     settings$.next({ ...$settings$, ...update })
@@ -64,9 +64,9 @@
       saveRune().then(() => {
         initialized = true
       })
+    } else {
+      initialized = true
     }
-
-    initialized = true
   } else {
     initialized = true
   }

--- a/src/routes/connect/+page.svelte
+++ b/src/routes/connect/+page.svelte
@@ -12,13 +12,14 @@
   import Modal from '$lib/elements/Modal.svelte'
   import ConnectionSettings from '$lib/components/ConnectionSettings.svelte'
   import lightning from '$lib/lightning'
-  import { DOCS_CONNECT_LINK, DOCS_RUNE_LINK } from '$lib/constants'
+  import { DOCS_CONNECT_LINK, DOCS_RUNE_LINK, WS_PROXY } from '$lib/constants'
   import info from '$lib/icons/info'
   import check from '$lib/icons/check'
   import close from '$lib/icons/close'
   import arrow from '$lib/icons/arrow'
   import warning from '$lib/icons/warning'
   import caret from '$lib/icons/caret'
+  import type { PageData } from './$types'
 
   import {
     formatDate,
@@ -27,8 +28,52 @@
     validateParsedNodeAddress
   } from '$lib/utils'
   import CopyValue from '$lib/elements/CopyValue.svelte'
+  import type { Settings } from '$lib/types'
 
   type ConnectStatus = 'idle' | 'connecting' | 'success' | 'fail'
+
+  export let data: PageData
+  let initialized = false
+  let address = ''
+  let validAddress = false
+  let token = ''
+  let decodedRune: DecodedRune | null = null
+
+  // Connect via URL params
+  if (data.address && data.rune) {
+    address = data.address
+    token = data.rune
+    const connectionType = data.type || 'proxy' // direct | proxy | undefined
+    const connectionValue = data.value || WS_PROXY // proxyUrl | wss: | ws: | undefined
+
+    if (validateParsedNodeAddress(parseNodeAddress(address)) && decode(token)) {
+      const update: Partial<Settings> = {}
+
+      if (connectionType === 'proxy') {
+        // @TODO validate custom proxy
+        update.wsProxy = connectionValue
+        update.directConnection = undefined
+      } else if (connectionType === 'direct') {
+        update.directConnection = connectionValue as 'ws:' | 'wss:' | undefined
+      }
+
+      settings$.next({ ...$settings$, ...update })
+
+      saveRune().then(() => {
+        initialized = true
+      })
+    }
+
+    initialized = true
+  } else {
+    initialized = true
+  }
+
+  $: {
+    if (validAddress && decodedRune) {
+      saveRune()
+    }
+  }
 
   let focusConnectionInput: () => void
   let focusRuneInput: () => void
@@ -61,8 +106,6 @@
     slide = to
   }
 
-  let address = ''
-  let validAddress = false
   let connectStatus: ConnectStatus = 'idle'
   let sessionPublicKey: string
   let sessionPrivateKey: string
@@ -79,14 +122,11 @@
     }
   }
 
-  let token = ''
-  let decodedRune: DecodedRune | null = null
-
   $: if (token) {
     decodedRune = decode(token)
 
     if (decodedRune) {
-      blurRuneInput()
+      blurRuneInput && blurRuneInput()
     }
   }
 
@@ -229,217 +269,225 @@
 
 <svelte:window on:keydown={handleKeyPress} />
 
-{#if slide === 'connect'}
-  <Slide
-    back={() => goto('/welcome')}
-    backText={$translate('app.titles./welcome')}
-    direction={slideDirection}
-  >
-    <section class="w-full p-4 max-w-lg m-auto pt-16">
-      <div class="mb-6">
-        <h1 class="text-4xl font-bold mb-4">{$translate('app.headings.connect')}</h1>
-        <p class="text-neutral-600 dark:text-neutral-300">
-          {$translate('app.subheadings.connect')}
-        </p>
-      </div>
-
-      <div class="flex items-center mb-6 font-thin text-sm dark:text-purple-200 text-purple-700">
-        <div class="w-5 mr-2 border-2 rounded-full border-current">
-          {@html info}
+{#if initialized}
+  {#if slide === 'connect'}
+    <Slide
+      back={() => goto('/welcome')}
+      backText={$translate('app.titles./welcome')}
+      direction={slideDirection}
+    >
+      <section class="w-full p-4 max-w-lg m-auto pt-16">
+        <div class="mb-6">
+          <h1 class="text-4xl font-bold mb-4">{$translate('app.headings.connect')}</h1>
+          <p class="text-neutral-600 dark:text-neutral-300">
+            {$translate('app.subheadings.connect')}
+          </p>
         </div>
-        <a
-          href={DOCS_CONNECT_LINK}
-          target="_blank"
-          class="hover:underline"
-          rel="noopener noreferrer">{$translate('app.hints.help')}</a
-        >
-      </div>
 
-      <div class="w-full">
-        <div class="relative w-full flex flex-col">
-          <TextInput
-            name="address"
-            type="textarea"
-            rows={6}
-            label={$translate('app.inputs.node_connect.label')}
-            invalid={address && !validAddress ? $translate('app.inputs.node_connect.invalid') : ''}
-            placeholder={$translate('app.inputs.node_connect.placeholder')}
-            bind:value={address}
-            bind:focus={focusConnectionInput}
-            on:focus={resetConnectStatus}
-          />
+        <div class="flex items-center mb-6 font-thin text-sm dark:text-purple-200 text-purple-700">
+          <div class="w-5 mr-2 border-2 rounded-full border-current">
+            {@html info}
+          </div>
+          <a
+            href={DOCS_CONNECT_LINK}
+            target="_blank"
+            class="hover:underline"
+            rel="noopener noreferrer">{$translate('app.hints.help')}</a
+          >
+        </div>
 
+        <div class="w-full">
+          <div class="relative w-full flex flex-col">
+            <TextInput
+              name="address"
+              type="textarea"
+              rows={6}
+              label={$translate('app.inputs.node_connect.label')}
+              invalid={address && !validAddress
+                ? $translate('app.inputs.node_connect.invalid')
+                : ''}
+              placeholder={$translate('app.inputs.node_connect.placeholder')}
+              bind:value={address}
+              bind:focus={focusConnectionInput}
+              on:focus={resetConnectStatus}
+            />
+
+            <div
+              in:fade|local={{ duration: 250 }}
+              class="flex items-center text-sm absolute bottom-1 right-1"
+            >
+              {#if connectStatus === 'success'}
+                <div class="flex items-center">
+                  <span class="text-utility-success"
+                    >{$translate('app.inputs.add_rune.success')}</span
+                  >
+                  <div class="w-6 text-utility-success">
+                    {@html check}
+                  </div>
+                </div>
+              {:else if connectStatus === 'fail'}
+                <div class="flex items-center">
+                  <span class="text-utility-error">{$translate('app.errors.node_connect')}</span>
+                  <div class="w-6 text-utility-error">
+                    {@html close}
+                  </div>
+                </div>
+              {/if}
+            </div>
+          </div>
+
+          <button
+            on:click={() => (expandConnectionSettings = !expandConnectionSettings)}
+            class="mt-4 flex items-center text-sm cursor-pointer"
+          >
+            <div class:-rotate-90={!expandConnectionSettings} class="w-3 mr-1 transition-transform">
+              {@html caret}
+            </div>
+            <span class="font-semibold underline">Advanced</span>
+          </button>
+
+          <!-- ADVANCED SETTINGS -->
           <div
             in:fade|local={{ duration: 250 }}
-            class="flex items-center text-sm absolute bottom-1 right-1"
+            class:h-28={!!expandConnectionSettings}
+            class="text-sm mt-2 pl-4 pr-[1px] flex flex-col items-start overflow-y-hidden h-0 transition-all"
           >
-            {#if connectStatus === 'success'}
-              <div class="flex items-center">
-                <span class="text-utility-success">{$translate('app.inputs.add_rune.success')}</span
-                >
-                <div class="w-6 text-utility-success">
-                  {@html check}
-                </div>
+            <ConnectionSettings
+              bind:invalid={invalidConnectionOptions}
+              bind:save={saveConnectionSettings}
+            />
+          </div>
+
+          <div class="w-full mt-6">
+            <Button
+              bind:this={connectButton}
+              disabled={!validAddress || invalidConnectionOptions}
+              on:click={attemptConnect}
+              requesting={connectStatus === 'connecting'}
+              text={$translate(`app.buttons.${connectStatus === 'idle' ? 'connect' : 'try_again'}`)}
+            />
+          </div>
+        </div>
+      </section>
+    </Slide>
+  {/if}
+
+  {#if slide === 'token'}
+    <Slide {back} backText={$translate(`app.labels.${previousSlide}`)} direction={slideDirection}>
+      <section class="w-full p-4 max-w-lg m-auto pt-16">
+        <h1 class="text-4xl font-bold mb-4">{$translate('app.headings.rune')}</h1>
+        <p class="text-neutral-600 dark:text-neutral-300">{$translate('app.subheadings.rune')}</p>
+
+        {#if sessionPublicKey}
+          <div
+            class="my-4
+      font-semibold"
+          >
+            <CopyValue value={sessionPublicKey} truncateLength={9} />
+          </div>
+        {/if}
+
+        <div class="w-full">
+          <p class="text-neutral-600 dark:text-neutral-300">
+            {$translate('app.inputs.add_rune.recipes')}
+          </p>
+          <div class="flex gap-1 my-4 font-semibold">
+            {#each recipes as recipe (recipe)}
+              <div class="flex items-center justify-center w-full text-sm border rounded py-1">
+                <CopyValue
+                  value={createRuneRecipe(recipe, sessionPublicKey)}
+                  label={$translate(`app.inputs.add_rune.${recipe}`)}
+                />
               </div>
-            {:else if connectStatus === 'fail'}
-              <div class="flex items-center">
-                <span class="text-utility-error">{$translate('app.errors.node_connect')}</span>
-                <div class="w-6 text-utility-error">
-                  {@html close}
-                </div>
-              </div>
-            {/if}
+            {/each}
           </div>
         </div>
 
-        <button
-          on:click={() => (expandConnectionSettings = !expandConnectionSettings)}
-          class="mt-4 flex items-center text-sm cursor-pointer"
-        >
-          <div class:-rotate-90={!expandConnectionSettings} class="w-3 mr-1 transition-transform">
-            {@html caret}
-          </div>
-          <span class="font-semibold underline">Advanced</span>
-        </button>
-
-        <!-- ADVANCED SETTINGS -->
         <div
-          in:fade|local={{ duration: 250 }}
-          class:h-28={!!expandConnectionSettings}
-          class="text-sm mt-2 pl-4 pr-[1px] flex flex-col items-start overflow-y-hidden h-0 transition-all"
+          class="flex items-center w-full justify-between mb-6 font-thin text-sm dark:text-purple-200 text-purple-700"
         >
-          <ConnectionSettings
-            bind:invalid={invalidConnectionOptions}
-            bind:save={saveConnectionSettings}
-          />
+          <div class="flex items-center">
+            <div class="w-5 mr-2 border-2 rounded-full border-current">
+              {@html info}
+            </div>
+            <a
+              href={DOCS_RUNE_LINK}
+              target="_blank"
+              class="hover:underline"
+              rel="noopener noreferrer">{$translate('app.hints.help')}</a
+            >
+          </div>
+
+          {#if decodedRune}
+            <div in:fade|local={{ duration: 250 }}>
+              <Button text="Decode Rune" on:click={() => (showDecodedRuneModal = true)} small />
+            </div>
+          {/if}
+        </div>
+
+        <div class="w-full">
+          <div class="relative w-full">
+            <TextInput
+              name="token"
+              type="textarea"
+              rows={3}
+              label={$translate('app.inputs.add_rune.label')}
+              placeholder={$translate('app.inputs.add_rune.placeholder')}
+              bind:value={token}
+              bind:focus={focusRuneInput}
+              bind:blur={blurRuneInput}
+            />
+          </div>
         </div>
 
         <div class="w-full mt-6">
           <Button
-            bind:this={connectButton}
-            disabled={!validAddress || invalidConnectionOptions}
-            on:click={attemptConnect}
-            requesting={connectStatus === 'connecting'}
-            text={$translate(`app.buttons.${connectStatus === 'idle' ? 'connect' : 'try_again'}`)}
-          />
-        </div>
-      </div>
-    </section>
-  </Slide>
-{/if}
-
-{#if slide === 'token'}
-  <Slide {back} backText={$translate(`app.labels.${previousSlide}`)} direction={slideDirection}>
-    <section class="w-full p-4 max-w-lg m-auto pt-16">
-      <h1 class="text-4xl font-bold mb-4">{$translate('app.headings.rune')}</h1>
-      <p class="text-neutral-600 dark:text-neutral-300">{$translate('app.subheadings.rune')}</p>
-
-      {#if sessionPublicKey}
-        <div
-          class="my-4
-      font-semibold"
-        >
-          <CopyValue value={sessionPublicKey} truncateLength={9} />
-        </div>
-      {/if}
-
-      <div class="w-full">
-        <p class="text-neutral-600 dark:text-neutral-300">
-          {$translate('app.inputs.add_rune.recipes')}
-        </p>
-        <div class="flex gap-1 my-4 font-semibold">
-          {#each recipes as recipe (recipe)}
-            <div class="flex items-center justify-center w-full text-sm border rounded py-1">
-              <CopyValue
-                value={createRuneRecipe(recipe, sessionPublicKey)}
-                label={$translate(`app.inputs.add_rune.${recipe}`)}
-              />
-            </div>
-          {/each}
-        </div>
-      </div>
-
-      <div
-        class="flex items-center w-full justify-between mb-6 font-thin text-sm dark:text-purple-200 text-purple-700"
-      >
-        <div class="flex items-center">
-          <div class="w-5 mr-2 border-2 rounded-full border-current">
-            {@html info}
-          </div>
-          <a href={DOCS_RUNE_LINK} target="_blank" class="hover:underline" rel="noopener noreferrer"
-            >{$translate('app.hints.help')}</a
+            bind:this={saveRuneButton}
+            on:click={saveRune}
+            text={$translate('app.buttons.save')}
           >
-        </div>
-
-        {#if decodedRune}
-          <div in:fade|local={{ duration: 250 }}>
-            <Button text="Decode Rune" on:click={() => (showDecodedRuneModal = true)} small />
-          </div>
-        {/if}
-      </div>
-
-      <div class="w-full">
-        <div class="relative w-full">
-          <TextInput
-            name="token"
-            type="textarea"
-            rows={3}
-            label={$translate('app.inputs.add_rune.label')}
-            placeholder={$translate('app.inputs.add_rune.placeholder')}
-            bind:value={token}
-            bind:focus={focusRuneInput}
-            bind:blur={blurRuneInput}
-          />
-        </div>
-      </div>
-
-      <div class="w-full mt-6">
-        <Button
-          bind:this={saveRuneButton}
-          on:click={saveRune}
-          text={$translate('app.buttons.save')}
-        >
-          <div slot="iconRight" class="w-6 -rotate-90">
-            {@html arrow}
-          </div>
-        </Button>
-      </div>
-    </section>
-  </Slide>
-{/if}
-
-{#if showDecodedRuneModal && decodedRune}
-  <Modal on:close={() => (showDecodedRuneModal = false)}>
-    <div in:fade|local={{ duration: 250 }} class="w-[25rem] max-w-full h-full overflow-auto">
-      <h4 class="font-semibold mb-2 w-full text-2xl">{$translate('app.labels.rune_summary')}</h4>
-
-      <SummaryRow>
-        <span slot="label">{$translate('app.labels.id')}:</span>
-        <span slot="value">{decodedRune.id}</span>
-      </SummaryRow>
-
-      <SummaryRow>
-        <span slot="label">{$translate('app.labels.hash')}:</span>
-        <span slot="value">{truncateValue(decodedRune.hash)}</span>
-      </SummaryRow>
-
-      <SummaryRow baseline>
-        <span slot="label">{$translate('app.labels.restrictions')}:</span>
-        <p slot="value">
-          {#if decodedRune.restrictions.length === 0}
-            <div class="flex items-center">
-              <div class="w-4 mr-2 text-utility-pending">
-                {@html warning}
-              </div>
-              <span class="text-utility-pending">{$translate('app.hints.unrestricted')}</span>
+            <div slot="iconRight" class="w-6 -rotate-90">
+              {@html arrow}
             </div>
-          {:else}
-            {#await formattedRestrictions then formatted}
-              {@html formatted.join('<span class="text-xs mr-2"><i><br>AND<br></i></span>')}
-            {/await}
-          {/if}
-        </p>
-      </SummaryRow>
-    </div>
-  </Modal>
+          </Button>
+        </div>
+      </section>
+    </Slide>
+  {/if}
+
+  {#if showDecodedRuneModal && decodedRune}
+    <Modal on:close={() => (showDecodedRuneModal = false)}>
+      <div in:fade|local={{ duration: 250 }} class="w-[25rem] max-w-full h-full overflow-auto">
+        <h4 class="font-semibold mb-2 w-full text-2xl">{$translate('app.labels.rune_summary')}</h4>
+
+        <SummaryRow>
+          <span slot="label">{$translate('app.labels.id')}:</span>
+          <span slot="value">{decodedRune.id}</span>
+        </SummaryRow>
+
+        <SummaryRow>
+          <span slot="label">{$translate('app.labels.hash')}:</span>
+          <span slot="value">{truncateValue(decodedRune.hash)}</span>
+        </SummaryRow>
+
+        <SummaryRow baseline>
+          <span slot="label">{$translate('app.labels.restrictions')}:</span>
+          <p slot="value">
+            {#if decodedRune.restrictions.length === 0}
+              <div class="flex items-center">
+                <div class="w-4 mr-2 text-utility-pending">
+                  {@html warning}
+                </div>
+                <span class="text-utility-pending">{$translate('app.hints.unrestricted')}</span>
+              </div>
+            {:else}
+              {#await formattedRestrictions then formatted}
+                {@html formatted.join('<span class="text-xs mr-2"><i><br>AND<br></i></span>')}
+              {/await}
+            {/if}
+          </p>
+        </SummaryRow>
+      </div>
+    </Modal>
+  {/if}
 {/if}

--- a/src/routes/connect/+page.svelte
+++ b/src/routes/connect/+page.svelte
@@ -38,6 +38,7 @@
   let validAddress = false
   let token = ''
   let decodedRune: DecodedRune | null = null
+  let sessionPrivateKey: string
 
   // Connect via URL params
   if (data.address && data.rune) {
@@ -51,23 +52,26 @@
     // Set connection type
     if (connectionType === 'direct') {
       update.directConnection = connectionValue as 'ws:' | 'wss:' | undefined
+      // Default to clams proxy
     } else if (connectionType === 'proxy' && connectionValue) {
-      // @TODO validate custom proxy?
       update.wsProxy = connectionValue
       update.directConnection = undefined
     }
 
     settings$.next({ ...$settings$, ...update })
 
-    // Validate address & rune then save to make connection
+    // Validate address & rune
     if (validateParsedNodeAddress(parseNodeAddress(address)) && decode(token)) {
+      // Attempt connection
       saveRune().then(() => {
         initialized = true
       })
     } else {
+      // Show forms that render invalid address or rune errors
       initialized = true
     }
   } else {
+    // Show page if no address & rune query params found
     initialized = true
   }
 
@@ -104,7 +108,6 @@
 
   let connectStatus: ConnectStatus = 'idle'
   let sessionPublicKey: string
-  let sessionPrivateKey: string
   let showDecodedRuneModal = false
   const recipes = ['readonly', 'clams', 'admin'] as const
 

--- a/src/routes/connect/+page.svelte
+++ b/src/routes/connect/+page.svelte
@@ -71,12 +71,6 @@
     initialized = true
   }
 
-  $: {
-    if (validAddress && decodedRune) {
-      saveRune()
-    }
-  }
-
   let focusConnectionInput: () => void
   let focusRuneInput: () => void
   let blurRuneInput: () => void

--- a/src/routes/connect/+page.ts
+++ b/src/routes/connect/+page.ts
@@ -1,0 +1,15 @@
+import type { PageLoad } from './$types'
+
+export const load: PageLoad = async ({ url }) => {
+  const address = url.searchParams.get('address') // nodeId@hostname:port
+  const rune = url.searchParams.get('rune') // admin rune
+  const type = url.searchParams.get('type') // direct | proxy
+  const value = url.searchParams.get('value') // proxyUrl | wss:
+
+  return {
+    address,
+    rune,
+    type,
+    value
+  }
+}


### PR DESCRIPTION
This PR updates /connect route to include the option to pass connection details via URL params. Params are: 

- `address`
- `rune`
- `type`
- `value` 

For example:

```
http://localhost:5173/connect?address=03093b030028e642fc3b9a05c8eb549f202958e92143da2e85579b92ef0f49cc7d@localhost:7272&rune=rLiwnD_eiPt5js1TUaNBoj0rX24KU2IzE3NCm5sL5uw9Ng==&type=direct&value=ws:
```

Note - `address` & `rune` are mandatory. `type` and `value` will default to the clams proxy like the app does already. 