### PR TITLE
1.7.0-0.2.2 - Enhancement - Node Info QR

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-app",
-  "version": "1.7.0-0.1.2",
+  "version": "1.7.0-0.2.2",
   "scripts": {
     "dev": "vite dev",
     "dev-http": "vite dev --mode http",

--- a/src/lib/components/PaymentDetails.svelte
+++ b/src/lib/components/PaymentDetails.svelte
@@ -135,7 +135,7 @@
   <!-- QR AND EXPIRY COUNTDOWN -->
   {#if payment.direction === 'receive' && payment.status === 'pending'}
     <div class="my-4 flex flex-col items-center justify-center">
-      <Qr value={payment.invoice || null} />
+      <Qr value={`lightning:${payment.invoice}` || null} />
       {#if payment.expiresAt}
         <div class="mt-2">
           <ExpiryCountdown on:expired={handlePaymentExpire} expiry={new Date(payment.expiresAt)} />

--- a/src/lib/components/QR.svelte
+++ b/src/lib/components/QR.svelte
@@ -26,7 +26,7 @@
       width: size,
       height: size,
       type: 'svg',
-      data: `lightning:${value}`.toUpperCase(),
+      data: value.toUpperCase(),
       imageOptions: { hideBackgroundDots: false, imageSize: 0.25, margin: 0 },
       dotsOptions: {
         type: 'dots',

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -257,7 +257,10 @@ export const calculateBalance = (funds: ListfundsResponse): string => {
     return total.add(formatMsat(our_amount_msat))
   }, Big('0'))
 
-  const onChain = funds.outputs.reduce((total, { amount_msat }) => total.add(formatMsat(amount_msat)), Big('0'))
+  const onChain = funds.outputs.reduce(
+    (total, { amount_msat }) => total.add(formatMsat(amount_msat)),
+    Big('0')
+  )
 
   return offChain.add(onChain).toString()
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { fade } from 'svelte/transition'
   import { translate } from '$lib/i18n/translations'
-  import { funds$, nodeInfo$, settings$ } from '$lib/streams'
+  import { auth$, funds$, nodeInfo$, settings$ } from '$lib/streams'
   import { calculateBalance, isPWA, logger } from '$lib/utils'
   import Spinner from '$lib/elements/Spinner.svelte'
   import Value from '$lib/components/Value.svelte'
@@ -15,6 +15,9 @@
   import scan from '$lib/icons/scan'
   import CopyValue from '$lib/elements/CopyValue.svelte'
   import key from '$lib/icons/key.js'
+  import qr from '$lib/icons/qr.js'
+  import Modal from '$lib/elements/Modal.svelte'
+  import Qr from '$lib/components/QR.svelte'
 
   const buttons = [
     { key: 'send', icon: arrow, styles: 'rotate-180' },
@@ -48,6 +51,8 @@
       logger.warn('Could not register bitcoin protocol handler')
     }
   }
+
+  let showNodeInfoModal = false
 </script>
 
 <svelte:head>
@@ -67,11 +72,17 @@
         class="flex items-center w-full justify-center text-xl p-4"
       >
         <Refresh />
+
         <div class="ml-2 mt-[2px] flex items-center">
           <b>{$nodeInfo$.data.alias}</b>
+
           <div class="ml-1 mb-1">
             <CopyValue value={$nodeInfo$.data.id} hideValue truncateLength={6} icon={key} />
           </div>
+
+          <button on:click={() => (showNodeInfoModal = true)} class="block w-6 ml-1 mb-1">
+            {@html qr}
+          </button>
         </div>
       </div>
     {/if}
@@ -103,3 +114,15 @@
 
   <RecentPayment />
 </div>
+
+{#if showNodeInfoModal && $auth$}
+  <Modal on:close={() => (showNodeInfoModal = false)}>
+    <h4 class="font-semibold mb-4 w-full text-2xl">
+      {$nodeInfo$.data?.alias}
+    </h4>
+
+    <div class="mb-6">
+      <Qr value={$auth$.address} />
+    </div>
+  </Modal>
+{/if}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -15,9 +15,9 @@
   import scan from '$lib/icons/scan'
   import CopyValue from '$lib/elements/CopyValue.svelte'
   import key from '$lib/icons/key.js'
-  import qr from '$lib/icons/qr.js'
   import Modal from '$lib/elements/Modal.svelte'
   import Qr from '$lib/components/QR.svelte'
+  import info from '$lib/icons/info.js'
 
   const buttons = [
     { key: 'send', icon: arrow, styles: 'rotate-180' },
@@ -76,12 +76,11 @@
         <div class="ml-2 mt-[2px] flex items-center">
           <b>{$nodeInfo$.data.alias}</b>
 
-          <div class="ml-1 mb-1">
-            <CopyValue value={$nodeInfo$.data.id} hideValue truncateLength={6} icon={key} />
-          </div>
-
-          <button on:click={() => (showNodeInfoModal = true)} class="block w-6 ml-1 mb-1">
-            {@html qr}
+          <button
+            on:click={() => (showNodeInfoModal = true)}
+            class="w-6 ml-2 mb-[2px] border-2 border-current rounded-full flex items-center justify-center"
+          >
+            {@html info}
           </button>
         </div>
       </div>
@@ -117,11 +116,15 @@
 
 {#if showNodeInfoModal && $auth$}
   <Modal on:close={() => (showNodeInfoModal = false)}>
-    <h4 class="font-semibold mb-4 w-full text-2xl">
+    <h4 class="font-semibold mb-2 w-full text-3xl">
       {$nodeInfo$.data?.alias}
     </h4>
 
-    <div class="mb-6">
+    <div class="mb-4 w-full flex justify-start font-semibold">
+      <CopyValue value={$nodeInfo$.data?.id || ''} truncateLength={12} icon={key} />
+    </div>
+
+    <div class="mb-8">
       <Qr value={$auth$.address} />
     </div>
   </Modal>

--- a/src/routes/channels/[id]/+page.svelte
+++ b/src/routes/channels/[id]/+page.svelte
@@ -451,7 +451,7 @@
     <div class="w-[25rem] max-w-full gap-y-4 flex flex-col overflow-hidden h-full">
       <h4 class="font-semibold mb-2 w-full text-2xl">{$translate('app.labels.channel_fees')}</h4>
 
-      <div class="flex flex-col flex-grow overflow-auto">
+      <div class="flex flex-col flex-grow overflow-auto p-1">
         <TextInput
           type="number"
           name="base"

--- a/src/routes/channels/open/+page.svelte
+++ b/src/routes/channels/open/+page.svelte
@@ -12,6 +12,9 @@
   import lightning from '$lib/lightning.js'
   import { parseNodeAddress, validateParsedNodeAddress } from '$lib/utils.js'
   import { slide } from 'svelte/transition'
+  import type { PageData } from './$types.js'
+
+  export let data: PageData
 
   let address: string
   let channelSize: number
@@ -22,6 +25,10 @@
   let errMsg = ''
 
   let showScanner = false
+
+  if (data.address) {
+    address = data.address
+  }
 
   $: if (address) {
     try {

--- a/src/routes/channels/open/+page.ts
+++ b/src/routes/channels/open/+page.ts
@@ -1,0 +1,6 @@
+import type { PageLoad } from './$types'
+
+export const load: PageLoad = async ({ url }) => {
+  const address = url.searchParams.get('address')
+  return { address }
+}

--- a/src/routes/offers/[id]/+page.svelte
+++ b/src/routes/offers/[id]/+page.svelte
@@ -213,7 +213,7 @@
         <!-- QR AND EXPIRY COUNTDOWN -->
         {#if status === 'active'}
           <div class="my-4 flex flex-col items-center justify-center">
-            <Qr value={bolt12} />
+            <Qr value={`lightning:${bolt12}`} />
             {#if offerExpiry}
               <div class="mt-2">
                 <ExpiryCountdown

--- a/src/routes/scan/+page.svelte
+++ b/src/routes/scan/+page.svelte
@@ -11,7 +11,13 @@
   import { convertValue } from '$lib/conversion'
   import lightning from '$lib/lightning'
   import Amount from '$lib/components/Amount.svelte'
-  import { createRandomHex, decodeBolt11, parseBitcoinUrl } from '$lib/utils'
+  import {
+    createRandomHex,
+    decodeBolt11,
+    parseBitcoinUrl,
+    parseNodeAddress,
+    validateParsedNodeAddress
+  } from '$lib/utils'
 
   import {
     BitcoinDenomination,
@@ -33,6 +39,12 @@
   let value = ''
 
   async function handleScanResult(scanResult: string) {
+    // node address to open channel to
+    if (validateParsedNodeAddress(parseNodeAddress(scanResult))) {
+      await goto(`/channels/open?address=${scanResult}`)
+      return
+    }
+
     const parsed = parseBitcoinUrl(scanResult)
     const { error } = parsed as ParsedBitcoinStringError
 
@@ -50,13 +62,13 @@
 
     // lnurl
     if (type === 'lnurl') {
-      goto(`/lnurl?lnurl=${parsedValue}`)
+      await goto(`/lnurl?lnurl=${parsedValue}`)
       return
     }
 
     // Bolt 12 Offers
     if (type === 'bolt12') {
-      goto(`/offers/bolt12/${parsedValue}`)
+      await goto(`/offers/bolt12/${parsedValue}`)
       return
     }
 


### PR DESCRIPTION
- Adds new info button and associated modal that will display the copyable node public key as well as a QR for the node connection address that can be scanned:

<img width="50%" alt="Screenshot 2023-07-10 at 7 56 39 am" src="https://github.com/clams-tech/browser-app/assets/29873495/f4fc34f9-25b6-4fb1-818a-97089d91bd49">
<img width="402" alt="Screenshot 2023-07-10 at 7 56 24 am" src="https://github.com/clams-tech/browser-app/assets/29873495/d88950de-145c-46bc-8c46-7372d0db5f00">

- Scan route scanner can now recognise a node address, will redirect to `/channels/open?address<node_address>` passing the scanned node address. The channels open route will automatically fill in the node address if picked up in the search params.
